### PR TITLE
⚡️ use first heading if no title specified

### DIFF
--- a/bin/vitePluginCompiiile/models/Context.js
+++ b/bin/vitePluginCompiiile/models/Context.js
@@ -109,8 +109,13 @@ export default class {
 								.replace(/<a.*aria-hidden.*>.*?<\/a>|<[^>]*>?/gi, "")
 								.replace(/[\r\n]{2,}/g, "\n")
 						)
+
+						const firstHeading = renderedMarkdown.metadata.headings.length ?
+							renderedMarkdown.metadata.headings[0].text.replaceAll('#', '') :
+							false;
+
 						const meta = renderedMarkdown.metadata.frontmatter
-						fileListItem.title = meta.title || fileName
+						fileListItem.title = meta.title || firstHeading || fileName
 						fileListItem.meta = meta
 						fileListItem.meta.title = fileListItem.meta.title || fileListItem.title
 						fileListItem.fullPath = filePath


### PR DESCRIPTION
If there isn't a title used in the front matter, then use the first heading in the document (if there is one)

Saves adding front matter just for the title 