### PR TITLE
⚡️ allow index.md instead of readme

### DIFF
--- a/bin/vitePluginCompiiile/models/Context.js
+++ b/bin/vitePluginCompiiile/models/Context.js
@@ -37,7 +37,7 @@ export default class {
 			.map((val) => slugify(val, { lower: true }))
 			.join("/")
 
-		if (sluggifiedPath === "readme") {
+		if (sluggifiedPath === "readme" || sluggifiedPath === "index") {
 			if (process.env.VITE_COMPIIILE_BASE !== "/") {
 				return process.env.VITE_COMPIIILE_BASE
 			}


### PR DESCRIPTION
Allow for use of `index.md` instead of `readme.md`.

There are currently no checks to see if both exist