### PR TITLE
🔧 Fix Windows path resolution for astro config dirs

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -5,6 +5,7 @@ import compiiile from "./vitePluginCompiiile/index.js"
 import mdx from "@astrojs/mdx"
 import path from "node:path"
 import { copyFileSync, cpSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import markdownConfig from "./vitePluginCompiiile/markdownConfig.js"
 import resolvePackagePath from "resolve-package-path"
 import requireg from "requireg"
@@ -19,7 +20,7 @@ import yargs from "yargs/yargs"
 import { hideBin } from "yargs/helpers"
 
 import { readFile } from "fs/promises"
-const packageJSON = JSON.parse(await readFile(new URL("../package.json", import.meta.url)))
+const packageJSON = JSON.parse(await readFile(fileURLToPath(path.join(import.meta.url, "../../package.json"))))
 
 /*
  Order of options by priority:
@@ -113,7 +114,7 @@ const publicDir = path.resolve(source, "./.compiiile/public")
 
 if (argv.logo) {
 	try {
-		cpSync(new URL("../.compiiile/public", import.meta.url).pathname, publicDir, { recursive: true })
+		cpSync(fileURLToPath(path.join(import.meta.url, "../.compiiile/public")), publicDir, { recursive: true })
 		copyFileSync(path.resolve(source, argv.logo), path.resolve(publicDir, "favicon.png"))
 		// Set the logo to be displayed on the top bar if we were able to copy
 		process.env.VITE_COMPIIILE_LOGO = argv.logo
@@ -128,7 +129,11 @@ import { createRequire } from "node:module"
 const require = createRequire(import.meta.url)
 const pathName = require.resolve("@fontsource-variable/archivo")
 import { packageDirectory } from "pkg-dir"
-const viteServerFsAllowList = [source, new URL("../", import.meta.url).pathname, path.resolve(pathName, "../../")]
+const viteServerFsAllowList = [
+	source,
+	fileURLToPath(path.join(import.meta.url, "../")),
+	path.resolve(pathName, "../../")
+]
 const packageDir = await packageDirectory()
 if (packageDir) {
 	viteServerFsAllowList.push(packageDir)
@@ -145,8 +150,8 @@ const astroConfig = {
 		host: argv.host,
 		port: argv.port
 	},
-	root: new URL("../.compiiile", import.meta.url).pathname,
-	srcDir: new URL("../.compiiile/src", import.meta.url).pathname,
+	root: fileURLToPath(path.join(import.meta.url, "../.compiiile")),
+	srcDir: fileURLToPath(path.join(import.meta.url, "../.compiiile/src")),
 	outDir: path.join(source, argv.dest || ".compiiile/dist"),
 	...(argv.logo ? { publicDir } : {}),
 	integrations: [


### PR DESCRIPTION
This fixes path resolution on Windows (#22) and at least gets us to booting the Astro dev server. Further errors still preventing compiiile from working as intended on Windows.